### PR TITLE
add slightly deeper checking for a 'browser' environment. 

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -341,7 +341,7 @@ var log4javascript = (function() {
     /* ---------------------------------------------------------------------- */
     /* Browser-related */
 
-    if (typeof window != UNDEFINED) {
+    if (typeof window != UNDEFINED && typeof window.document != UNDEFINED) {
         var BrowserEnvironment = function() {
             this.isBrowser = true;
         };


### PR DESCRIPTION
In NetSuite (a Rhino based js runtime) there is a global [window] variable defined, which caused this check to fall short.
